### PR TITLE
Add \r to prints manually

### DIFF
--- a/source/mesh_system.c
+++ b/source/mesh_system.c
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <stdio.h>
 #include "eventOS_scheduler.h"
 #include "eventOS_event.h"
 #include "net_interface.h"
@@ -53,6 +54,13 @@ static void mesh_system_heap_error_handler(heap_fail_t event)
     while (1);
 }
 
+// mbed fails to auto-add CR before LF when outputting over the
+// serial port, so \n is not sufficient to get a proper newline.
+static void trace_print(const char *str)
+{
+    printf("%s\r\n", str);
+}
+
 void mesh_system_init(void)
 {
     if (mesh_initialized == false) {
@@ -62,6 +70,7 @@ void mesh_system_init(void)
         platform_timer_enable();
         eventOS_scheduler_init();
         trace_init(); // trace system needs to be initialized right after eventOS_scheduler_init
+        set_trace_print_function(trace_print);
         net_init_core();
         /* initialize 6LoWPAN socket adaptation layer */
         ns_sal_init_stack();


### PR DESCRIPTION
mbed stdout->serial implementation doesn't output CR before LF, but
terminals tend to want this - they usually interpret LF as just moving the
cursor down.

Hence any mbed code printing to stdout currently has to use "\r\n" to move
the cursor to the start of the next line - this idiom is pervasive in mbed
code, but should not be necessary as \n is defined by the C standard as
moving to the start of the next line.

Register a custom trace printer that has the required extra \r hack.

Problem is usually concealed by the fact that the trace formatter normally
outputs an explicit \r and VT100 line blank at the start of each line
(presumably to overwrite ongoing command input), but it becomes apparent
if someone mixes trace and non-trace output.

Is there any chance of fixing mbed's _sys_write that underlies stdio?

On POSIX, the program would still output \n as LF, but the output device
would have ONLCR enabled to map that to CR-LF. Here, where we are writing
directly to a raw serial device, it would make sense for _sys_write to
add CR if outputting to serial in text mode. (This is what we do when
porting Nanostack to non-mbed systems).
