### PR TITLE
Make nanostack heap size configurable via yotta.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This module supports static configuration via [yotta configuration](#http://yott
 
 ```
   "mbed-mesh-api": {
+    "heap_size": 32500,
     "thread": {
       "pskd": "\"Secret password\"",
       "device_type": "MESH_DEVICE_TYPE_THREAD_ROUTER",
@@ -41,6 +42,12 @@ This module supports static configuration via [yotta configuration](#http://yott
     }
   }
 ```
+
+Configurable parameters in section: mbed-mesh-api
+
+| Parameter name  | Value         | Description |
+| --------------- | ------------- | ----------- |
+| heap_size       | number [0-0xfffe] | Nanostack internal heap size |
 
 Configurable parameters in section: mbed-mesh-api/thread
 

--- a/source/mesh_system.c
+++ b/source/mesh_system.c
@@ -28,7 +28,11 @@
 #define TRACE_GROUP  "m6-mesh-system"
 
 /* Heap for NanoStack */
+#ifdef YOTTA_CFG_MBED_MESH_API_HEAP_SIZE
+#define MESH_HEAP_SIZE YOTTA_CFG_MBED_MESH_API_HEAP_SIZE
+#else
 #define MESH_HEAP_SIZE 32500
+#endif
 static uint8_t app_stack_heap[MESH_HEAP_SIZE + 1];
 static bool mesh_initialized = false;
 


### PR DESCRIPTION
Add a new configuration item for tuning the statically
reserved heap size. The application side may override
the default value by setting the heap_size value in
its config.json.

For example:
"mbed-mesh-api": {
<..>
    "heap_size": 32500,
<..>
}