### PR TITLE
[ONME-2784] Mem leak fix.

### DIFF
--- a/source/nd_tasklet.c
+++ b/source/nd_tasklet.c
@@ -72,6 +72,7 @@ typedef struct {
 
 /* Tasklet data */
 static tasklet_data_str_t *tasklet_data_ptr = NULL;
+static mac_api_t *mac_api;
 
 /* private function prototypes */
 void nd_tasklet_main(arm_event_s *event);
@@ -427,7 +428,9 @@ int8_t nd_tasklet_network_init(int8_t device_id)
     storage_sizes.key_description_table_size = 3;
     storage_sizes.key_lookup_size = 1;
     storage_sizes.key_usage_size = 3;
-    mac_api_t *api = ns_sw_mac_create(device_id, &storage_sizes);
-    return arm_nwk_interface_lowpan_init(api, INTERFACE_NAME);
+    if(!mac_api)  {
+        mac_api = ns_sw_mac_create(device_id, &storage_sizes);
+    }
+    return arm_nwk_interface_lowpan_init(mac_api, INTERFACE_NAME);
 }
 


### PR DESCRIPTION
- Multiple init calls to mbed-mesh-api must not create a new MAC API instance.

@artokin @kjbracey-arm @SeppoTakalo 
